### PR TITLE
Mutate elements of array in parallel example using Rayon library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ toml = "0.3"
 petgraph = "0.4.3"
 crossbeam = "0.2"
 clap = "2.20.5"
+rayon = "0.6.0"
 
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A practical guide to the Rust crate ecosystem.
 ### [JSON](src/pages/json.md) [![json][json-badge]][json]
 ### [TOML](src/pages/toml.md) [![toml][toml-badge]][toml]
 ### [rand](src/pages/rand.md) [![rand][rand-badge]][rand]
+### [rayon](src/pages/rayon.md) [![rayon][rayon-badge]][rayon]
 
 ## Contributing
 If you'd like to make changes to the project, please see [this guide](CONTRIBUTING.md).
@@ -32,5 +33,7 @@ MIT/Apache-2.0
 [toml]: http://alexcrichton.com/toml-rs/toml/
 [rand-badge]: https://img.shields.io/crates/v/rand.svg?label=rand
 [rand]: https://doc.rust-lang.org/rand/rand/index.html
-[error-docs]: https://doc.rust-lang.org/book/error-handling.html 
+[error-docs]: https://doc.rust-lang.org/book/error-handling.html
 [error-blog]: https://brson.github.io/2016/11/30/starting-with-error-chain
+[rayon-badge]: https://img.shields.io/crates/v/rayon.svg?label=rayon
+[rayon]: https://doc.rust-lang.org/rayon/rayon/index.html

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -16,5 +16,7 @@
     - [JSON](pages/json.md)
     - [TOML](pages/toml.md)
 - [Networking](pages/networking.md)
+- [Concurrency](pages/concurrency.md)
+    - [Rayon](pages/rayon.md)
 
 [Contributing](pages/contributing.md)

--- a/src/pages/concurrency.md
+++ b/src/pages/concurrency.md
@@ -1,0 +1,1 @@
+# Concurrency

--- a/src/pages/rayon.md
+++ b/src/pages/rayon.md
@@ -1,0 +1,32 @@
+# Rayon
+[![rayon-badge]][rayon]
+
+## Mutate the elements of an array using parallel processing
+
+```rust
+
+/**
+ * An example of mutating array elements in parallel using rayon
+ *
+ */
+
+extern crate rayon;
+use rayon::prelude::*;
+
+fn main() {
+    let arr = &mut [0, 7, 9, 11];
+
+    arr.par_iter_mut().for_each(|p| *p -= 1);
+
+    println!("{:?}", arr);
+}
+
+```
+
+The example uses the Rayon crate, which is the data parallelism library for Rust. It defines the trait, ParallelIterator, which provides the par_iter_mut() method. This method is actually a call to get a parallel iterator. It lets us write iterator-like chains that execute in parallel. It constructs the values we want and for_each() method, i.e.,the 'operations' method actually carries out the execution.
+
+
+<!-- Links -->
+
+[rayon-badge]: https://img.shields.io/crates/v/rayon.svg?label=rayon
+[rayon]: https://docs.rs/rayon

--- a/src/pages/table_of_contents.md
+++ b/src/pages/table_of_contents.md
@@ -17,6 +17,8 @@ A practical guide to the Rust crate ecosystem.
     - [JSON](pages/json.html) [![json-badge]][json]
     - [TOML](pages/toml.html) [![toml-badge]][toml]
 - [Networking](pages/networking.html)
+- [Concurrency](pages/concurrency.html)
+    - [Rayon](pages/rayon.html)
 
 ## Contributing
 If you'd like to make changes to the project, please see [this guide](pages/contributing.html).
@@ -40,9 +42,11 @@ MIT/Apache-2.0
 [toml]: http://alexcrichton.com/toml-rs/toml/
 [rand-badge]: https://img.shields.io/crates/v/rand.svg?label=rand
 [rand]: https://doc.rust-lang.org/rand/rand/index.html
-[error-docs]: https://doc.rust-lang.org/book/error-handling.html 
+[error-docs]: https://doc.rust-lang.org/book/error-handling.html
 [error-blog]: https://brson.github.io/2016/11/30/starting-with-error-chain
 [petgraph-badge]: https://img.shields.io/crates/v/petgraph.svg?label=petgraph
 [petgraph]: https://docs.rs/petgraph/0.4.3/petgraph/
 [crossbeam-badge]: https://img.shields.io/crates/v/crossbeam.svg?label=crossbeam
 [crossbeam]: https://docs.rs/crossbeam
+[rayon-badge]: https://img.shields.io/crates/v/rayon.svg?label=rayon
+[rayon]: https://docs.rs/rayon


### PR DESCRIPTION
The example in the commit demonstrates how difference on each element of array is calculated in parallel (instead of sequential computation) using Rayon library in Rust.