### PR TITLE
Implemented "Make a HTTP GET request" example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 toml = "0.4"
 url = "1.4"
+reqwest = "0.5"
 
 [build-dependencies]
 skeptic = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 toml = "0.4"
 url = "1.4"
-reqwest = "0.5"
+reqwest = "0.6"
 
 [build-dependencies]
 skeptic = "0.9"

--- a/src/intro.md
+++ b/src/intro.md
@@ -48,7 +48,7 @@ community. It needs and welcomes help. For details see
 | [Extract the URL origin (scheme / host / port)][ex-url-origin] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
 | [Remove fragment identifiers and query pairs from a URL][ex-url-rm-frag] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
 | [Serialize a `Url`][ex-url-serialize] | [![url-badge]][url] [![serde-badge]][serde] | [![cat-net-badge]][cat-net] [![cat-encoding-badge]][cat-encoding]|
-| [Make a HTTP GET request after parsing a URL][ex-url-reqwest] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
+| [Make a HTTP GET request after parsing a URL][ex-url-basic] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
 
 ## [Application development](app.html)
 
@@ -121,4 +121,4 @@ Keep lines sorted.
 [ex-url-origin]: net.html#ex-url-origin
 [ex-url-rm-frag]: net.html#ex-url-rm-frag
 [ex-url-serialize]: net.html#ex-url-serialize
-[ex-url-reqwest]: net.html#ex-url-reqwest
+[ex-url-basic]: net.html#ex-url-basic

--- a/src/intro.md
+++ b/src/intro.md
@@ -48,7 +48,7 @@ community. It needs and welcomes help. For details see
 | [Extract the URL origin (scheme / host / port)][ex-url-origin] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
 | [Remove fragment identifiers and query pairs from a URL][ex-url-rm-frag] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
 | [Serialize a `Url`][ex-url-serialize] | [![url-badge]][url] [![serde-badge]][serde] | [![cat-net-badge]][cat-net] [![cat-encoding-badge]][cat-encoding]|
-| [Make a HTTP GET request after parsing a URL][ex-url-reqwest] | [![reqwest-badge]][reqwest] [![url-badge]][url] | [![cat-net-badge]][cat-net] |
+| [Make a HTTP GET request after parsing a URL][ex-url-reqwest] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
 
 ## [Application development](app.html)
 

--- a/src/net.md
+++ b/src/net.md
@@ -8,7 +8,7 @@
 | [Extract the URL origin (scheme / host / port)][ex-url-origin] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
 | [Remove fragment identifiers and query pairs from a URL][ex-url-rm-frag] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
 | [Serialize a `Url`][ex-url-serialize] | [![url-badge]][url] [![serde-badge]][serde] | [![cat-net-badge]][cat-net] [![cat-encoding-badge]][cat-encoding]|
-| [Make a HTTP GET request after parsing a URL][ex-url-reqwest] | [![reqwest-badge]][reqwest] [![url-badge]][url] | [![cat-net-badge]][cat-net] |
+| [Make a HTTP GET request][ex-url-reqwest] | [![reqwest-badge]][reqwest] [![url-badge]][url] | [![cat-net-badge]][cat-net] |
 
 [ex-url-parse]: #ex-url-parse
 <a name="ex-url-parse"/>
@@ -234,10 +234,39 @@ fn main() {
 
 [ex-url-reqwest]: #ex-url-reqwest
 <a name="ex-url-reqwest"></a>
-## Make a HTTP GET request after parsing a URL
+## Make a HTTP GET request
 
-[Write me!](https://github.com/brson/rust-cookbook/issues/39)
+The [`reqwest::get`] function parses the supplied url and makes a
+synchronus HTTP GET request. Obtained [`reqwest::Response`]
+status and headders are printed and custom `Result` with allocated `String` containing the HTTP response body is returned.
 
+```rust,no_run
+extern crate reqwest;
+#[macro_use]
+extern crate error_chain;
+use std::io::Read;
+
+error_chain! {
+    foreign_links {
+        Io(std::io::Error);
+        HttpReqest(reqwest::Error);
+    }
+}
+
+fn http_get_body() -> Result<String> {
+    let mut res = reqwest::get("http://httpbin.org/get")?;
+    println!("Status: {}", res.status());
+    println!("Headers:\n{}", res.headers());
+    let mut body = String::new();
+    res.read_to_string(&mut body)?;
+    Ok(body)
+}
+
+fn main() {
+    let body = http_get_body().unwrap();
+    println!("Body:\n{}", body);
+}
+```
 <!-- Categories -->
 
 [cat-encoding-badge]: https://img.shields.io/badge/-encoding-red.svg
@@ -248,7 +277,7 @@ fn main() {
 <!-- Crates -->
 
 [reqwest-badge]: https://img.shields.io/crates/v/reqwest.svg?label=reqwest
-[reqwest]: https://docs.rs/url/
+[reqwest]: https://docs.rs/reqwest/
 [serde-badge]: https://img.shields.io/crates/v/serde.svg?label=serde
 [serde]: https://docs.rs/serde/
 [url-badge]: https://img.shields.io/crates/v/url.svg?label=url
@@ -261,3 +290,5 @@ fn main() {
 [`url::Position`]: https://docs.rs/url/*/url/enum.Position.html
 [`origin`]: https://docs.rs/url/1.*/url/struct.Url.html#method.origin
 [`join`]: https://docs.rs/url/1.*/url/struct.Url.html#method.join
+[`reqwest::get`]: https://docs.rs/reqwest/*/reqwest/fn.get.html
+[`reqwest::Response`]: https://docs.rs/reqwest/*/reqwest/struct.Response.html

--- a/src/net.md
+++ b/src/net.md
@@ -8,7 +8,7 @@
 | [Extract the URL origin (scheme / host / port)][ex-url-origin] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
 | [Remove fragment identifiers and query pairs from a URL][ex-url-rm-frag] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
 | [Serialize a `Url`][ex-url-serialize] | [![url-badge]][url] [![serde-badge]][serde] | [![cat-net-badge]][cat-net] [![cat-encoding-badge]][cat-encoding]|
-| [Make a HTTP GET request][ex-url-reqwest] | [![reqwest-badge]][reqwest] [![url-badge]][url] | [![cat-net-badge]][cat-net] |
+| [Make a HTTP GET request][ex-url-basic] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
 
 [ex-url-parse]: #ex-url-parse
 <a name="ex-url-parse"/>
@@ -232,18 +232,21 @@ fn main() {
 
 [Write me!](https://github.com/brson/rust-cookbook/issues/38)
 
-[ex-url-reqwest]: #ex-url-reqwest
-<a name="ex-url-reqwest"></a>
+[ex-url-basic]: #ex-url-basic
+<a name="ex-url-basic"></a>
 ## Make a HTTP GET request
+
+[![reqwest-badge]][reqwest] [![cat-net-badge]][cat-net]
 
 The [`reqwest::get`] function parses the supplied url and makes a
 synchronus HTTP GET request. Obtained [`reqwest::Response`]
-status and headders are printed and custom `Result` with allocated `String` containing the HTTP response body is returned.
+status and headders are printed. HTTP response body is read into an allocated [`String`] via [`read_to_string`].
 
 ```rust,no_run
 extern crate reqwest;
 #[macro_use]
 extern crate error_chain;
+
 use std::io::Read;
 
 error_chain! {
@@ -253,19 +256,19 @@ error_chain! {
     }
 }
 
-fn http_get_body() -> Result<String> {
+fn run() -> Result<()> {
     let mut res = reqwest::get("http://httpbin.org/get")?;
-    println!("Status: {}", res.status());
-    println!("Headers:\n{}", res.headers());
     let mut body = String::new();
     res.read_to_string(&mut body)?;
-    Ok(body)
+
+    println!("Status: {}", res.status());
+    println!("Headers:\n{}", res.headers());
+    println!("Body:\n{}", body);
+
+    Ok(())
 }
 
-fn main() {
-    let body = http_get_body().unwrap();
-    println!("Body:\n{}", body);
-}
+quick_main!(run);
 ```
 <!-- Categories -->
 
@@ -292,3 +295,5 @@ fn main() {
 [`join`]: https://docs.rs/url/1.*/url/struct.Url.html#method.join
 [`reqwest::get`]: https://docs.rs/reqwest/*/reqwest/fn.get.html
 [`reqwest::Response`]: https://docs.rs/reqwest/*/reqwest/struct.Response.html
+[`read_to_string`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_to_string
+[`String`]: https://doc.rust-lang.org/std/string/struct.String.html


### PR DESCRIPTION
I took the liberty of adding reqwest to cargo.toml and renaming
"Make a HTTP GET request after parsing a URL" to "Make a HTTP GET request"
as reqwest handles basic URL parsing internally and there seamed
no reason to make the example more complex than required.

Also `rust,no_run` skeptic annotation was used to allow for compilation without making actual http requests.

resolves: https://github.com/brson/rust-cookbook/issues/39
blocked by: https://github.com/seanmonstar/reqwest/pull/79

Unfortunately reqwest is still dependent on serde 0.9 which causes our "encoding.md" examples to fail. Until https://github.com/seanmonstar/reqwest/pull/79 is resolved I would be happy to resolve any problems with the PR.