### PR TITLE
Make consistent table column widths

### DIFF
--- a/theme/book.css
+++ b/theme/book.css
@@ -825,6 +825,14 @@ table {
   width: 100%;
 }
 
+table td:first-child{
+  width: 60%;
+}
+
+table td:nth-child(2){
+  width: 20%;
+}
+
 pre > .buttons {
   display: none;
 }


### PR DESCRIPTION
Added explicit width values for first and second
table columns corresponding to "Recipe" and "Crates".
Please note that this is a broad CSS style for all tables
which will break any non TOC tables.

For a cleaner solution we would need to explicitly
add class attribute to the generated HTML.

resolves: https://github.com/brson/rust-cookbook/issues/42