### PR TITLE
Add placeholders for log examples

### DIFF
--- a/src/app.md
+++ b/src/app.md
@@ -3,6 +3,11 @@
 | Recipe | Crates | Categories |
 |--------|--------|------------|
 | [Parse command line arguments][ex-clap-basic] | [![clap-badge]][clap] | [![cat-command-line-badge]][cat-command-line] |
+| [Log a debug message to the console][ex-log-debug] | [![log-badge]][log] [![env_logger-badge]][env_logger] | [![cat-command-line-badge]][cat-command-line] |
+| [Log an error message to the console][ex-log-error] | [![log-badge]][log] [![env_logger-badge]][env_logger] | [![cat-command-line-badge]][cat-command-line] |
+| [Enable log levels per module][ex-log-mod] | [![log-badge]][log] [![env_logger-badge]][env_logger] | [![cat-command-line-badge]][cat-command-line] |
+| [Log to the Unix syslog][ex-log-syslog] | [![log-badge]][log] [![syslog-badge]][syslog] | [![cat-debugging-badge]][cat-debugging] |
+| [Log messages to a custom location][ex-log-custom] | [![log-badge]][log] | [![cat-command-line-badge]][cat-command-line] |
 
 [ex-clap-basic]: #ex-clap-basic
 <a name="ex-clap-basic"></a>
@@ -99,12 +104,63 @@ The file passed is: myfile.txt
 Your favorite number must be 256.
 ```
 
+[ex-log-debug]: #ex-log-debug
+<a name="ex-log-debug"></a>
+## Log a debug message to the console
+
+[![log-badge]][log] [![env_logger-badge]][env_logger] [![cat-command-line-badge]][cat-command-line]
+
+[Write me!](https://github.com/brson/rust-cookbook/issues/61)
+
+[ex-log-error]: #ex-log-error
+<a name="ex-log-error"></a>
+## Log an error message to the console
+
+[![log-badge]][log] [![env_logger-badge]][env_logger] [![cat-command-line-badge]][cat-command-line]
+
+[Write me!](https://github.com/brson/rust-cookbook/issues/61)
+
+[ex-log-mod]: #ex-log-mod
+<a name="ex-log-mod"></a>
+## Enable log levels per module
+
+[![log-badge]][log] [![env_logger-badge]][env_logger] [![cat-command-line-badge]][cat-command-line]
+
+[Write me!](https://github.com/brson/rust-cookbook/issues/61)
+
+[ex-log-syslog]: #ex-log-syslog
+<a name="ex-log-syslog"></a>
+## Log to the Unix syslog
+
+[![log-badge]][log] [![syslog-badge]][syslog] [![cat-debugging-badge]][cat-debugging]
+
+[Write me!](https://github.com/brson/rust-cookbook/issues/61)
+
+[ex-log-custom]: #ex-log-custom
+<a name="ex-log-custom"></a>
+## Log messages to a custom location
+
+[![log-badge]][log] [![cat-command-line-badge]][cat-command-line]
+
+[Write me!](https://github.com/brson/rust-cookbook/issues/61)
+
+
 <!-- Categories -->
 
 [cat-command-line-badge]: https://img.shields.io/badge/-command_line-red.svg
 [cat-command-line]: https://crates.io/categories/command-line-interface
+[cat-debugging-badge]: https://img.shields.io/badge/-debugging-red.svg
+[cat-debugging]: https://crates.io/categories/debugging
 
 <!-- Crates -->
 
 [clap-badge]: https://img.shields.io/crates/v/clap.svg?label=clap
 [clap]: https://docs.rs/clap/
+[env_logger-badge]: https://img.shields.io/crates/v/clap.svg?label=env_logger
+[env_logger]: https://docs.rs/env_logger/
+[log-badge]: https://img.shields.io/crates/v/clap.svg?label=log
+[log]: https://docs.rs/log/
+[log_syslog-badge]: https://img.shields.io/crates/v/clap.svg?label=log_syslog
+[log_syslog]: https://docs.rs/log_syslog/
+[syslog-badge]: https://img.shields.io/crates/v/toml.svg?label=syslog
+[syslog]: https://docs.rs/syslog/

--- a/src/intro.md
+++ b/src/intro.md
@@ -55,6 +55,12 @@ community. It needs and welcomes help. For details see
 | Recipe | Crates | Categories |
 |--------|--------|------------|
 | [Parse command line arguments][ex-clap-basic] | [![clap-badge]][clap] | [![cat-command-line-badge]][cat-command-line] |
+| [Log a debug message to the console][ex-log-debug] | [![log-badge]][log] [![env_logger-badge]][env_logger] | [![cat-debugging-badge]][cat-debugging] |
+| [Log an error message to the console][ex-log-error] | [![log-badge]][log] [![env_logger-badge]][env_logger] | [![cat-debugging-badge]][cat-debugging] |
+| [Enable log levels per module][ex-log-mod] | [![log-badge]][log] [![env_logger-badge]][env_logger] | [![cat-debugging-badge]][cat-debugging] |
+| [Log to the Unix syslog][ex-log-syslog] | [![log-badge]][log] [![syslog-badge]][syslog] | [![cat-debugging-badge]][cat-debugging] |
+| [Log messages to a custom location][ex-log-custom] | [![log-badge]][log] | [![cat-debugging-badge]][cat-debugging] |
+
 
 <!--
 
@@ -73,6 +79,8 @@ Keep lines sorted.
 [cat-command-line]: https://crates.io/categories/command-line-interface
 [cat-concurrency-badge]: https://img.shields.io/badge/-concurrency-red.svg
 [cat-concurrency]: https://crates.io/categories/concurrency
+[cat-debugging-badge]: https://img.shields.io/badge/-debugging-red.svg
+[cat-debugging]: https://crates.io/categories/debugging
 [cat-filesystem-badge]: https://img.shields.io/badge/-filesystem-red.svg
 [cat-filesystem]: https://crates.io/categories/filesystem
 [cat-science-badge]: https://img.shields.io/badge/-science-red.svg
@@ -88,6 +96,10 @@ Keep lines sorted.
 [byteorder]: https://docs.rs/byteorder/
 [clap-badge]: https://img.shields.io/crates/v/clap.svg?label=clap
 [clap]: https://docs.rs/clap/
+[env_logger-badge]: https://img.shields.io/crates/v/clap.svg?label=env_logger
+[env_logger]: https://docs.rs/env_logger/
+[log-badge]: https://img.shields.io/crates/v/clap.svg?label=log
+[log]: https://docs.rs/log/
 [serde-json-badge]: https://img.shields.io/crates/v/serde_json.svg?label=serde_json
 [serde-json]: https://docs.serde.rs/serde_json/
 [rand-badge]: https://img.shields.io/crates/v/rand.svg?label=rand
@@ -100,6 +112,8 @@ Keep lines sorted.
 [serde]: https://docs.rs/serde/
 [std-badge]: https://img.shields.io/badge/std-1.17.0-blue.svg
 [std]: https://doc.rust-lang.org/std
+[syslog-badge]: https://img.shields.io/crates/v/toml.svg?label=syslog
+[syslog]: https://docs.rs/syslog/
 [toml-badge]: https://img.shields.io/crates/v/toml.svg?label=toml
 [toml]: https://docs.rs/toml/
 [url-badge]: https://img.shields.io/crates/v/url.svg?label=url
@@ -110,6 +124,11 @@ Keep lines sorted.
 [ex-byteorder-le]: basics.html#ex-byteorder-le
 [ex-clap-basic]: app.html#ex-clap-basic
 [ex-json-value]: encoding.html#ex-json-value
+[ex-log-custom]: app.html#ex-log-custom
+[ex-log-debug]: app.html#ex-log-debug
+[ex-log-error]: app.html#ex-log-error
+[ex-log-mod]: app.html#ex-log-mod
+[ex-log-syslog]: app.html#ex-log-syslog
 [ex-rand-custom]: basics.html#ex-rand-custom
 [ex-rand-float]: basics.html#ex-rand-float
 [ex-rayon-iter-mut]: concurrency.html#ex-rayon-iter-mut


### PR DESCRIPTION
r? @dtolnay 

cc https://github.com/brson/rust-cookbook/issues/61

I didn't add the entry for the 'syslog' example because I don't know which crate implements log for the syslog.