### PR TITLE
add crate-tasks link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,7 @@ Contribution will be open to a broader set of crates in the future.
 For more about which crates are represented in the cookbook, see ["a
 note about crate representation"][which-crates] in the cookbok.
 
+[crate-tasks]: https://github.com/brson/rust-cookbook/issues?q=is%3Aissue+is%3Aopen+label%3Acrate-tasks
 [which-crates]: https://brson.github.io/rust-cookbook/about.html#which-crates
 
 ## Adding an example


### PR DESCRIPTION
[crate-tasks] links to https://github.com/brson/rust-cookbook/issues?q=is%3Aissue+is%3Aopen+label%3Acrate-tasks

It's one other step in order to fix: https://github.com/brson/rust-cookbook/issues/63

(I'm making different PR for each step cause I think it's easier to review, not sure I'm right)