### PR TITLE
fix links in table of contents

### DIFF
--- a/src/about.md
+++ b/src/about.md
@@ -2,11 +2,11 @@
 
 ## Table of contents
 
-- [Who this book is for](#who)
-- [How to read this book](#reading)
-- [How to use the examples](#examples)
-- [A note about error handling](#errors)
-- [A note about crate representation](#which-crates)
+- [Who this book is for](#who-this-book-is-for)
+- [How to read this book](#how-to-read-this-book)
+- [How to use the examples](#how-to-use-the-examples)
+- [A note about error handling](#a-note-about-error-handling)
+- [A note about crate representation](#a-note-about-crate-representation)
 
 ## Who this book is for
 


### PR DESCRIPTION
The links in the table of contents of this page are broken: https://brson.github.io/rust-cookbook/about.html

This PR is vaguely related to https://github.com/brson/rust-cookbook/issues/63 and https://github.com/brson/rust-cookbook/issues/64