### PR TITLE
removed the stubs for "Serialize a `Url`" example

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -49,7 +49,6 @@ community. It needs and welcomes help. For details see
 | [Create new URLs from a base URL][ex-url-new-from-base] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
 | [Extract the URL origin (scheme / host / port)][ex-url-origin] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
 | [Remove fragment identifiers and query pairs from a URL][ex-url-rm-frag] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
-| [Serialize a `Url`][ex-url-serialize] | [![url-badge]][url] [![serde-badge]][serde] | [![cat-net-badge]][cat-net] [![cat-encoding-badge]][cat-encoding]|
 | [Make a HTTP GET request after parsing a URL][ex-url-basic] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
 | [Download a file to a temporary directory][ex-url-download] | [![reqwest-badge]][reqwest] [![tempdir-badge]][tempdir] | [![cat-net-badge]][cat-net] [![cat-filesystem-badge]][cat-filesystem] |
 | [Query the GitHub API][ex-rest-get] | [![reqwest-badge]][reqwest] [![serde-badge]][serde] | [![cat-net-badge]][cat-net] [![cat-encoding-badge]][cat-encoding] |
@@ -152,6 +151,5 @@ Keep lines sorted.
 [ex-url-new-from-base]: net.html#ex-url-new-from-base
 [ex-url-origin]: net.html#ex-url-origin
 [ex-url-rm-frag]: net.html#ex-url-rm-frag
-[ex-url-serialize]: net.html#ex-url-serialize
 [ex-url-download]: net.html#ex-url-download
 [ex-url-basic]: net.html#ex-url-basic

--- a/src/net.md
+++ b/src/net.md
@@ -7,7 +7,6 @@
 | [Create new URLs from a base URL][ex-url-new-from-base] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
 | [Extract the URL origin (scheme / host / port)][ex-url-origin] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
 | [Remove fragment identifiers and query pairs from a URL][ex-url-rm-frag] | [![url-badge]][url] | [![cat-net-badge]][cat-net] |
-| [Serialize a `Url`][ex-url-serialize] | [![url-badge]][url] [![serde-badge]][serde] | [![cat-net-badge]][cat-net] [![cat-encoding-badge]][cat-encoding]|
 | [Make a HTTP GET request][ex-url-basic] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
 | [Download a file to a temporary directory][ex-url-download] | [![reqwest-badge]][reqwest] [![tempdir-badge]][tempdir] | [![cat-net-badge]][cat-net] [![cat-filesystem-badge]][cat-filesystem] |
 | [Query the GitHub API][ex-rest-get] | [![reqwest-badge]][reqwest] [![serde-badge]][serde] | [![cat-net-badge]][cat-net] [![cat-encoding-badge]][cat-encoding] |
@@ -228,12 +227,6 @@ fn main() {
     run().unwrap();
 }
 ```
-
-[ex-url-serialize]: #ex-url-serialize
-<a name="ex-url-serialize"></a>
-## Serialize a `Url`
-
-[Write me!](https://github.com/brson/rust-cookbook/issues/38)
 
 [ex-url-basic]: #ex-url-basic
 <a name="ex-url-basic"></a>


### PR DESCRIPTION
resolves https://github.com/brson/rust-cookbook/issues/81