### PR TITLE
Travis "cron" builds run tests with "*" dependencies

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -12,6 +12,19 @@ if [ "$TRAVIS_BRANCH" != "master" ]; then
     exit 0
 fi
 
+# check for outdated dependencies on nightly builds
+if [ "${TRAVIS_EVENT_TYPE:-}" == "cron" ]; then
+    echo "This is cron build. Checking for outdated dependencies!"
+    rm ./Cargo.lock
+    cargo clean
+    # replace all [dependencies] versions with "*"
+    sed -i -e "/^\[dependencies\]/,/^\[.*\]/ s|^\(.*=[ \t]*\).*$|\1\"\*\"|" ./Cargo.toml
+
+    cargo test || { echo "Cron build failed! Dependencies outdated!"; exit 1; }
+    echo "Cron build success! Dependencies are up to date!"
+    exit 0
+fi
+
 # Returns 1 if program is installed and 0 otherwise
 program_installed() {
     local return_=1


### PR DESCRIPTION
"cron" builds will trigger cargo test with all dependency versions
replaced with "*" to check for incompatible dependencies.
Also cron builds will never publish gh-pages

This is somewhat hacky so I am open to suggestions. I guess that I would prefer to remove Cargo.lock altogether and replace dependency versions in Cargo.toml in the repo instead of modifying it on the fly but I see no other possibility to make dependency check only in Travis nightly.

reolves https://github.com/brson/rust-cookbook/issues/89

related to https://github.com/brson/rust-cookbook/issues/75
