### PR TITLE
Parsing subprocess output

### DIFF
--- a/src/basics.md
+++ b/src/basics.md
@@ -209,7 +209,7 @@ fn main() {
 [![regex-badge]][regex] [![cat-os-badge]][cat-os] [![cat-text-processing-badge]][cat-text-processing]
 
 `git log --oneline` is run as an external [`Command`] and its [`Output`] is
-inspected using [`Regex`] to get each commit's hash and message.
+inspected using [`Regex`] to get the hash and message of the last 5 commits.
 
 ```rust
 #[macro_use]
@@ -255,7 +255,8 @@ fn run() -> Result<()> {
                      hash: cap[1].to_string(),
                      message: cap[2].trim().to_string(),
                  }
-             });
+             })
+        .take(5);
 
     for commit in commits {
         println!("{:?}", commit);

--- a/src/basics.md
+++ b/src/basics.md
@@ -8,7 +8,8 @@
 | [Generate random numbers within a range][ex-rand-range] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Generate random numbers with normal distribution][ex-rand-dist] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Generate random values of a custom type][ex-rand-custom] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
-| [Run an External Command and Process Stdout][ex-parse-subprocess-output] | [![regex-badge]][regex] |  |
+| [Run an External Command and Process Stdout][ex-parse-subprocess-output] | [![regex-badge]][regex] | [![cat-os-badge]][cat-os] [![cat-text-processing-badge]][cat-text-processing] |
+
 
 
 [ex-std-read-lines]: #ex-std-read-lines
@@ -205,7 +206,7 @@ fn main() {
 <a name="ex-parse-subprocess-output"></a>
 ## Run an External Command and Process Stdout
 
-[![regex-badge]][regex] <!-- TODO: Find a category for this -->
+[![regex-badge]][regex] [![cat-os-badge]][cat-os] [![cat-text-processing-badge]][cat-text-processing]
 
 `git log --oneline` is run as an external [`Command`] and its [`Output`] is
 inspected using [`Regex`] to get each commit's hash and message.
@@ -275,6 +276,10 @@ quick_main!(run);
 [cat-filesystem]: https://crates.io/categories/filesystem
 [cat-science-badge]: https://img.shields.io/badge/-rand-red.svg
 [cat-science]: https://crates.io/categories/science
+[cat-os-badge]: https://img.shields.io/badge/-os-red.svg
+[cat-os]: https://crates.io/categories/os
+[cat-text-processing-badge]: https://img.shields.io/badge/-text_processing-red.svg
+[cat-text-processing]: https://crates.io/categories/text-processing
 
 <!-- Crates -->
 

--- a/src/intro.md
+++ b/src/intro.md
@@ -26,7 +26,7 @@ community. It needs and welcomes help. For details see
 | [Generate random numbers within a range][ex-rand-range] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Generate random numbers with normal distribution][ex-rand-dist] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Generate random values of a custom type][ex-rand-custom] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
-| [Run an External Command and Process Stdout][ex-parse-subprocess-output] | [![regex-badge]][regex] |  |
+| [Run an External Command and Process Stdout][ex-parse-subprocess-output] | [![regex-badge]][regex] | [![cat-os-badge]][cat-os] [![cat-text-processing-badge]][cat-text-processing] |
 
 ## [Encoding](encoding.html)
 
@@ -97,6 +97,10 @@ Keep lines sorted.
 [cat-net]: https://crates.io/categories/network-programming
 [cat-science-badge]: https://img.shields.io/badge/-science-red.svg
 [cat-science]: https://crates.io/categories/science
+[cat-os-badge]: https://img.shields.io/badge/-os-red.svg
+[cat-os]: https://crates.io/categories/os
+[cat-text-processing-badge]: https://img.shields.io/badge/-text_processing-red.svg
+[cat-text-processing]: https://crates.io/categories/text-processing
 
 <!-- Crates -->
 

--- a/src/intro.md
+++ b/src/intro.md
@@ -26,6 +26,7 @@ community. It needs and welcomes help. For details see
 | [Generate random numbers within a range][ex-rand-range] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Generate random numbers with normal distribution][ex-rand-dist] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Generate random values of a custom type][ex-rand-custom] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
+| [Run an External Command and Process Stdout][ex-parse-subprocess-output] | [![regex-badge]][regex] |  |
 
 ## [Encoding](encoding.html)
 
@@ -127,6 +128,8 @@ Keep lines sorted.
 [toml]: https://docs.rs/toml/
 [url-badge]: https://img.shields.io/crates/v/url.svg?label=url
 [url]: https://docs.rs/url/
+[regex]: https://docs.rs/regex/
+[regex-badge]: https://img.shields.io/crates/v/regex.svg?label=regex
 
 <!-- Examples -->
 
@@ -157,3 +160,4 @@ Keep lines sorted.
 [ex-url-origin]: net.html#ex-url-origin
 [ex-url-parse]: net.html#ex-url-parse
 [ex-url-rm-frag]: net.html#ex-url-rm-frag
+[ex-parse-subprocess-output]: basics.html#ex-parse-subprocess-output


### PR DESCRIPTION
This adds an example which calls `git log --oneline` in a subprocess and parses stdout to grab the hash and commit message for all commits in the current repo's history as discussed in #108.

I'm not quite sure which category this example belongs in. About the closes thing would be `filesystem`, but calling a subprocess doesn't really have anything to do with the filesystem...

(fixes #108)