### PR TITLE
Hide error_chain boiler plate by default in all examples

### DIFF
--- a/src/app.md
+++ b/src/app.md
@@ -130,12 +130,11 @@ Your favorite number must be 256.
 [![log-badge]][log] [![env_logger-badge]][env_logger] [![cat-debugging-badge]][cat-debugging]
 
 ```rust
+# #[macro_use]
+# extern crate error_chain;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
-
-#[macro_use]
-extern crate error_chain;
 
 mod foo {
     mod bar {
@@ -153,12 +152,12 @@ mod foo {
         bar::run();
     }
 }
-
-error_chain! {
-    foreign_links {
-        SetLogger(log::SetLoggerError);
-    }
-}
+#
+# error_chain! {
+#    foreign_links {
+#        SetLogger(log::SetLoggerError);
+#    }
+# }
 
 fn run() -> Result<()> {
     env_logger::init()?;
@@ -169,8 +168,8 @@ fn run() -> Result<()> {
 
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 [`env_logger`][env_logger] output is controlled by [`RUST_LOG`] environmental
@@ -204,11 +203,10 @@ Custom logger `ConsoleLogger` is implemented with [`log::Log`] trait and install
 via [`log::set_logger`]. Messages are logged to stdout.
 
 ```rust
+# #[macro_use]
+# extern crate error_chain;
 #[macro_use]
 extern crate log;
-
-#[macro_use]
-extern crate error_chain;
 
 use log::{LogRecord, LogLevel, LogMetadata, LogLevelFilter};
 
@@ -225,26 +223,26 @@ impl log::Log for ConsoleLogger {
         }
     }
 }
-
-error_chain! {
-    foreign_links {
-        SetLogger(log::SetLoggerError);
-    }
-}
+#
+# error_chain! {
+#    foreign_links {
+#        SetLogger(log::SetLoggerError);
+#    }
+# }
 
 fn run() -> Result<()> {
     log::set_logger(|max_log_level| {
                         max_log_level.set(LogLevelFilter::Info);
                         Box::new(ConsoleLogger)
                     })?;
-    
+
     info!("hello log");
     warn!("warning");
     error!("oops");
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 [ex-log-syslog]: #ex-log-syslog
@@ -260,21 +258,20 @@ with [`syslog::init`].
 and `Option<&str>` holds optional application name.
 
 ```rust,no_run
+# #[macro_use]
+# extern crate error_chain;
 #[macro_use]
 extern crate log;
 extern crate syslog;
 
-#[macro_use]
-extern crate error_chain;
-
 use log::LogLevelFilter;
 use syslog::Facility;
-
-error_chain! {
-    foreign_links {
-        SetLogger(log::SetLoggerError);
-    }
-}
+#
+# error_chain! {
+#    foreign_links {
+#        SetLogger(log::SetLoggerError);
+#    }
+# }
 
 fn run() -> Result<()> {
     syslog::init(Facility::LOG_USER, LogLevelFilter::Debug, Some("My app name"))?;
@@ -282,8 +279,8 @@ fn run() -> Result<()> {
     error!("this is an error!");
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 [ex-log-custom]: #ex-log-custom
@@ -299,25 +296,24 @@ First log file configuration is created using [`log4rs::append::file::FileAppend
 Then this is assigned to the [`log4rs::config::Config`] which has a root appender that uses the `logfile` appender that was just created, and sets the default [`log::LogLevelFilter`] so that any logs with `Info` level or higher will be sent to the logger.
 
 ```rust,no_run
+# #[macro_use]
+# extern crate error_chain;
 #[macro_use]
 extern crate log;
 extern crate log4rs;
-
-#[macro_use]
-extern crate error_chain;
 
 use log::LogLevelFilter;
 use log4rs::append::file::FileAppender;
 use log4rs::encode::pattern::PatternEncoder;
 use log4rs::config::{Appender, Config, Root};
-
-error_chain! {
-    foreign_links {
-        Io(std::io::Error);
-        LogConfig(log4rs::config::Errors);
-        SetLogger(log::SetLoggerError);
-    }
-}
+#
+# error_chain! {
+#    foreign_links {
+#        Io(std::io::Error);
+#        LogConfig(log4rs::config::Errors);
+#        SetLogger(log::SetLoggerError);
+#    }
+# }
 
 fn run() -> Result<()> {
     let logfile = FileAppender::builder()
@@ -334,13 +330,15 @@ fn run() -> Result<()> {
 
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 [ex-tar-temp]: #ex-tar-temp
 <a name="ex-tar-temp"></a>
 ## Unzip a tarball to a temporary directory
+
+[![flate2-badge]][flate2] [![tar-badge]][tar] [![tempdir-badge]][tempdir] [![cat-filesystem-badge]][cat-filesystem] [![cat-compression-badge]][cat-compression]
 
 Uncompress ([`flate2::read::GzDecoder::new`]) and
 extract ([`tar::Archive::unpack`]) all files form a zipped tarball
@@ -348,27 +346,23 @@ named archive.tar.gz located in the current working directory
 inside a temporary directory ([`tempdir::TempDir::new`])
 and delete everything.
 
-[![flate2-badge]][flate2] [![tar-badge]][tar] [![tempdir-badge]][tempdir] [![cat-filesystem-badge]][cat-filesystem] [![cat-compression-badge]][cat-compression]
-
 ```rust,no_run
-#[macro_use]
-extern crate error_chain;
+# #[macro_use]
+# extern crate error_chain;
 extern crate flate2;
 extern crate tar;
 extern crate tempdir;
 
 use std::fs::File;
-
 use flate2::read::GzDecoder;
 use tar::Archive;
 use tempdir::TempDir;
-
-
-error_chain! {
-    foreign_links {
-        Io(std::io::Error);
-    }
-}
+#
+# error_chain! {
+#    foreign_links {
+#        Io(std::io::Error);
+#    }
+# }
 
 fn run() -> Result<()> {
     let path = "archive.tar.gz";
@@ -387,23 +381,22 @@ fn run() -> Result<()> {
 
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 [ex-dedup-filenames]: #ex-dedup-filenames
 <a name="ex-dedup-filenames"></a>
 ## Recursively find duplicate file names
 
+[![walkdir-badge]][walkdir] [![cat-filesystem-badge]][cat-filesystem]
+
 Find recusively in the current directory duplicate filenames,
 printing them only once.
-
-[![walkdir-badge]][walkdir] [![cat-filesystem-badge]][cat-filesystem]
 
 ```rust,no_run
 extern crate walkdir;
 
 use std::collections::HashMap;
-
 use walkdir::WalkDir;
 
 fn main() {

--- a/src/basics.md
+++ b/src/basics.md
@@ -28,17 +28,17 @@ that implements [`Write`], here a [`File`]. The [`File`] is opened
 for writing with [`File::create`], and reading with [`File::open`].
 
 ```rust
-#[macro_use]
-extern crate error_chain;
-
+# #[macro_use]
+# extern crate error_chain;
+#
 use std::fs::File;
 use std::io::{Write, BufReader, BufRead};
-
-error_chain! {
-    foreign_links {
-        Io(std::io::Error);
-    }
-}
+#
+# error_chain! {
+#    foreign_links {
+#        Io(std::io::Error);
+#    }
+# }
 
 fn run() -> Result<()> {
     let path = "lines.txt";
@@ -55,8 +55,8 @@ fn run() -> Result<()> {
 
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 [ex-byteorder-le]: #ex-byteorder-le
@@ -66,10 +66,9 @@ quick_main!(run);
 [![byteorder-badge]][byteorder] [![cat-encoding-badge]][cat-encoding]
 
 ```rust
+# #[macro_use]
+# extern crate error_chain;
 extern crate byteorder;
-
-#[macro_use]
-extern crate error_chain;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
@@ -78,12 +77,12 @@ struct Payload {
     kind: u8,
     value: u16,
 }
-
-error_chain! {
-    foreign_links {
-        Io(std::io::Error);
-    }
-}
+#
+# error_chain! {
+#    foreign_links {
+#        Io(std::io::Error);
+#    }
+# }
 
 fn run() -> Result<()> {
     let original_payload = Payload::default();
@@ -107,8 +106,8 @@ fn decode(mut bytes: &[u8]) -> Result<Payload> {
     };
     Ok(payload)
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 [ex-rand-float]: #ex-rand-float
@@ -214,28 +213,26 @@ fn main() {
 inspected using [`Regex`] to get the hash and message of the last 5 commits.
 
 ```rust
-#[macro_use]
-extern crate error_chain;
+# #[macro_use]
+# extern crate error_chain;
 extern crate regex;
 
 use std::process::Command;
 use regex::Regex;
-
-error_chain!{
-    foreign_links {
-        Io(std::io::Error);
-        Regex(regex::Error);
-        Utf8(std::string::FromUtf8Error);
-    }
-}
-
+#
+# error_chain!{
+#    foreign_links {
+#        Io(std::io::Error);
+#        Regex(regex::Error);
+#        Utf8(std::string::FromUtf8Error);
+#    }
+# }
 
 #[derive(PartialEq, Default, Clone, Debug)]
 struct Commit {
     hash: String,
     message: String,
 }
-
 
 fn run() -> Result<()> {
     let output = Command::new("git").arg("log").arg("--oneline").output()?;
@@ -266,8 +263,8 @@ fn run() -> Result<()> {
 
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 [ex-lazy-constant]: #ex-lazy-constant
@@ -321,14 +318,14 @@ race conditions. A [`MutexGuard`] must be acquired to read or mutate the
 value stored in a [`Mutex`].
 
 ```rust
-#[macro_use]
-extern crate error_chain;
+# #[macro_use]
+# extern crate error_chain;
 #[macro_use]
 extern crate lazy_static;
 
 use std::sync::Mutex;
-
-error_chain!{ }
+#
+# error_chain!{ }
 
 lazy_static! {
     static ref FRUIT: Mutex<Vec<String>> = Mutex::new(Vec::new());
@@ -360,8 +357,8 @@ fn run() -> Result<()> {
     insert("grape")?;
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 <!-- Categories -->

--- a/src/encoding.md
+++ b/src/encoding.md
@@ -33,19 +33,18 @@ we expect the parsed value to be. The expected value is declared using the
 [`json!`]: https://docs.serde.rs/serde_json/macro.json.html
 
 ```rust
+# #[macro_use]
+# extern crate error_chain;
 #[macro_use]
 extern crate serde_json;
 
-#[macro_use]
-extern crate error_chain;
-
 use serde_json::Value;
-
-error_chain! {
-    foreign_links {
-        Json(serde_json::Error);
-    }
-}
+#
+# error_chain! {
+#    foreign_links {
+#        Json(serde_json::Error);
+#    }
+# }
 
 fn run() -> Result<()> {
     let j = r#"{
@@ -72,8 +71,8 @@ fn run() -> Result<()> {
 
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 [ex-toml-config]: #ex-toml-config
@@ -86,18 +85,17 @@ Parse some TOML into a universal `toml::Value` that is able to represent any
 valid TOML data.
 
 ```rust
+# #[macro_use]
+# extern crate error_chain;
 extern crate toml;
 
-#[macro_use]
-extern crate error_chain;
-
 use toml::Value;
-
-error_chain! {
-    foreign_links {
-        Toml(toml::de::Error);
-    }
-}
+#
+# error_chain! {
+#    foreign_links {
+#        Toml(toml::de::Error);
+#    }
+# }
 
 fn run() -> Result<()> {
     let toml_content = r#"
@@ -117,8 +115,8 @@ fn run() -> Result<()> {
 
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 Parse TOML into your own structs using Serde:
@@ -126,14 +124,12 @@ Parse TOML into your own structs using Serde:
 [![serde-json-badge]][serde-json] [![toml-badge]][toml] [![cat-encoding-badge]][cat-encoding]
 
 ```rust
+# #[macro_use]
+# extern crate error_chain;
 #[macro_use]
 extern crate serde_derive;
-
 extern crate serde;
 extern crate toml;
-
-#[macro_use]
-extern crate error_chain;
 
 use std::collections::HashMap;
 
@@ -149,12 +145,12 @@ struct Package {
     version: String,
     authors: Vec<String>,
 }
-
-error_chain! {
-    foreign_links {
-        Toml(toml::de::Error);
-    }
-}
+#
+# error_chain! {
+#    foreign_links {
+#        Toml(toml::de::Error);
+#    }
+# }
 
 fn run() -> Result<()> {
     let toml_content = r#"
@@ -176,8 +172,8 @@ fn run() -> Result<()> {
 
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 [ex-percent-encode]: #ex-percent-encode
@@ -191,18 +187,17 @@ function from the `url` crate. Then decode using the [`percent_decode`]
 function.
 
 ```rust
+# #[macro_use]
+# extern crate error_chain;
 extern crate url;
 
-#[macro_use]
-extern crate error_chain;
-
 use url::percent_encoding::{utf8_percent_encode, percent_decode, DEFAULT_ENCODE_SET};
-
-error_chain! {
-    foreign_links {
-        Utf8(std::str::Utf8Error);
-    }
-}
+#
+# error_chain! {
+#    foreign_links {
+#        Utf8(std::str::Utf8Error);
+#    }
+# }
 
 fn run() -> Result<()> {
     let input = "confident, productive systems programming";
@@ -217,8 +212,8 @@ fn run() -> Result<()> {
 
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 The encode set defines which bytes (in addition to non-ASCII and controls) need
@@ -277,24 +272,23 @@ hex `String` is then converted back to its original representation and is
 compared to the original value provided.
 
 ```rust
+# #[macro_use]
+# extern crate error_chain;
 extern crate data_encoding;
 
-#[macro_use]
-extern crate error_chain;
-
 use data_encoding::{HEXUPPER, DecodeError};
-
-error_chain! {
-    foreign_links {
-        Decode(DecodeError);
-    }
-}
+#
+# error_chain! {
+#    foreign_links {
+#        Decode(DecodeError);
+#    }
+# }
 
 fn run() -> Result<()> {
     let original = b"The quick brown fox jumps over the lazy dog.";
     let expected = "54686520717569636B2062726F776E20666F78206A756D7073206F76\
         657220746865206C617A7920646F672E";
-    
+
     let encoded = HEXUPPER.encode(original);
     assert_eq!(encoded, expected);
 
@@ -303,8 +297,8 @@ fn run() -> Result<()> {
 
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 [ex-base64]: #ex-base64
@@ -320,19 +314,19 @@ and subsequently decoded with [`decode`].
 [`encode`]: https://docs.rs/base64/*/base64/fn.encode.html
 
 ```rust
-#[macro_use]
-extern crate error_chain;
+# #[macro_use]
+# extern crate error_chain;
 extern crate base64;
 
 use std::str;
 use base64::{encode, decode};
-
-error_chain! {
-    foreign_links {
-        Base64(base64::DecodeError);
-        Utf8Error(str::Utf8Error);
-    }
-}
+#
+# error_chain! {
+#    foreign_links {
+#        Base64(base64::DecodeError);
+#        Utf8Error(str::Utf8Error);
+#    }
+# }
 
 fn run() -> Result<()> {
     let hello = b"hello rustaceans";
@@ -345,8 +339,8 @@ fn run() -> Result<()> {
 
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 <!-- Categories -->

--- a/src/net.md
+++ b/src/net.md
@@ -31,10 +31,9 @@ The URL in this code parses successfully, but swapping it out for a malformed
 URL will print a message containing an explanation of what went wrong.
 
 ```rust
-extern crate url;
-#
 # #[macro_use]
 # extern crate error_chain;
+extern crate url;
 
 use url::Url;
 #
@@ -539,18 +538,18 @@ In this example, the port is displayed on the console, and the program will
 listen until a request is made.  
 
 ```rust, no_run
-#[macro_use]
-extern crate error_chain;
-
+# #[macro_use]
+# extern crate error_chain;
+#
 use std::net::{SocketAddrV4, Ipv4Addr, TcpListener};
 use std::io::Read;
 
-error_chain! {
-    foreign_links {
-        Io(::std::io::Error);
-    }
-}
-
+# error_chain! {
+#    foreign_links {
+#        Io(::std::io::Error);
+#    }
+# }
+#
 fn run() -> Result<()> {
     let loopback = Ipv4Addr::new(127, 0, 0, 1);
     // Assigning port 0 requests the OS to assign a free port
@@ -566,8 +565,8 @@ fn run() -> Result<()> {
     println!("{:?} says {}", addr, input);
     Ok(())
 }
-
-quick_main!(run);
+#
+# quick_main!(run);
 ```
 
 The `std` library is leveraged to make a well formed IP/port with the


### PR DESCRIPTION
Modified all examples to hide noisy error_chain related code

resolves: https://github.com/brson/rust-cookbook/issues/106