### PR TITLE
Fix typo in ex-dedup-filenames

### DIFF
--- a/src/app.md
+++ b/src/app.md
@@ -404,7 +404,7 @@ fn main() {
     let mut filenames = HashMap::new();
 
     // List recusively all files in the current directory filtering out
-    // diretories and files not accessible (permission denied)
+    // directories and files not accessible (permission denied)
     for entry in WalkDir::new(".").into_iter()
                                   .filter_map(Result::ok)
                                   .filter(|e| !e.file_type().is_dir()) {


### PR DESCRIPTION
s/diretories/directories
in Application Development example Recursively find duplicate file names.