### PR TITLE
Removed passive voice from 7 examples

### DIFF
--- a/src/basics.md
+++ b/src/basics.md
@@ -132,7 +132,7 @@ fn main() {
 
 [![rand-badge]][rand] [![cat-science-badge]][cat-science]
 
-A random value within a range `[0, 10)` (not including `10`) is generated with [`Rng::gen_range`].
+Generates a random value within `[0, 10)` range (not including `10`) with [`Rng::gen_range`].
 
 ```rust
 extern crate rand;
@@ -151,8 +151,8 @@ fn main() {
 
 [![rand-badge]][rand] [![cat-science-badge]][cat-science]
 
-[`Normal`] distribution with mean `3` and standard deviation `5`
-is created. A random value is generated with [`IndependentSample::ind_sample`].
+Creates a [`Normal`] distribution with mean `3` and standard deviation `5`
+and generates a random value with [`IndependentSample::ind_sample`].
 
 ```rust
 extern crate rand;
@@ -173,9 +173,8 @@ fn main() {
 
 [![rand-badge]][rand] [![cat-science-badge]][cat-science]
 
-A tuple `(i32, bool, f64)` and variable of user defined type `Point`
-are randomly generated. In order to allow random generation of `Point`
-it needs to implement the [`rand::Rand`] trait.
+Randomly generates a tuple `(i32, bool, f64)` and variable of user defined type `Point`.
+Implements the [`rand::Rand`] trait for `Point` in order to allow random generation.
 
 ```rust
 extern crate rand;

--- a/src/encoding.md
+++ b/src/encoding.md
@@ -230,9 +230,9 @@ collected into a `String`.
 
 [![url-badge]][url] [![cat-encoding-badge]][cat-encoding]
 
-A string is encoded into [application/x-www-form-urlencoded] syntax
+Encodes a string into [application/x-www-form-urlencoded] syntax
 using the [`form_urlencoded::byte_serialize`] and subsequently
-decoded with [`form_urlencoded::parse`]. Both functions return iterators
+decodes it with [`form_urlencoded::parse`]. Both functions return iterators
 that can be collected into a `String`.
 
 ```rust

--- a/src/net.md
+++ b/src/net.md
@@ -238,7 +238,7 @@ fn run() -> Result<()> {
 
 [![url-badge]][url] [![cat-net-badge]][cat-net]
 
-Once [`Url`] is parsed it can be sliced with [`url::Position`] to strip unneeded URL parts.
+Parses [`Url`] and slices it with [`url::Position`] to strip unneeded URL parts.
 
 ```rust
 # #[macro_use]
@@ -269,9 +269,9 @@ fn run() -> Result<()> {
 
 [![reqwest-badge]][reqwest] [![cat-net-badge]][cat-net]
 
-The [`reqwest::get`] function parses the supplied url and makes a
-synchronous HTTP GET request. Obtained [`reqwest::Response`]
-status and headers are printed. HTTP response body is read into an allocated [`String`] via [`read_to_string`].
+Parses the supplied URL and makes a synchronous HTTP GET request
+with [`reqwest::get`]. Prints obtained [`reqwest::Response`]
+status and headers subsequently reading HTTP response body into an allocated [`String`] via [`read_to_string`].
 
 ```rust,no_run
 # #[macro_use]
@@ -308,10 +308,11 @@ fn run() -> Result<()> {
 
 [![reqwest-badge]][reqwest] [![tempdir-badge]][tempdir] [![cat-net-badge]][cat-net] [![cat-filesystem-badge]][cat-filesystem]
 
-Temporary directory is created with [`TempDir::new`] and a file is synchronously
-downloaded over HTTP using [`reqwest::get`].
-Target [`File`] with name obtained from [`Response::url`] is created within [`TempDir::path`]
-and downloaded data is copied into it with [`io::copy`]. The temporary directory is implicitly removed on `run` function return.
+Creates a temporary directory with [`TempDir::new`] and  synchronously downloads
+a file over HTTP using [`reqwest::get`].
+Creates a target [`File`] with name obtained from [`Response::url`] within [`TempDir::path`]
+and copies downloaded data into it with [`io::copy`].
+The temporary directory is automatically removed on `run` function return.
 
 ```rust,no_run
 # #[macro_use]


### PR DESCRIPTION
- Generate random numbers within a range
- Generate random numbers with normal distribution
- Generate random values of a custom type
- Encode a string as application/x-www-form-urlencoded
- Remove fragment identifiers and query pairs from a URL
- Make a HTTP GET request
- Download a file to a temporary directory

Connected with: https://github.com/brson/rust-cookbook/issues/139