### PR TITLE
 Added "Compress a directory into tarball" example and reworded decompress example

### DIFF
--- a/src/app.md
+++ b/src/app.md
@@ -3,7 +3,7 @@
 | Recipe | Crates | Categories |
 |--------|--------|------------|
 | [Parse command line arguments][ex-clap-basic] | [![clap-badge]][clap] | [![cat-command-line-badge]][cat-command-line] |
-| [Decompress a tarball to a temporary directory][ex-tar-decompress] | [![flate2-badge]][flate2] [![tar-badge]][tar] [![tempdir-badge]][tempdir] | [![cat-filesystem-badge]][cat-filesystem] [![cat-compression-badge]][cat-compression] |
+| [Decompress a tarball][ex-tar-decompress] | [![flate2-badge]][flate2] [![tar-badge]][tar] | [![cat-compression-badge]][cat-compression] |
 | [Recursively find duplicate file names][ex-dedup-filenames] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Recursively find all files with given predicate][ex-file-predicate] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Recursively calculate file sizes at given depth][ex-file-sizes] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
@@ -105,27 +105,23 @@ Your favorite number must be 256.
 
 [ex-tar-decompress]: #ex-tar-decompress
 <a name="ex-tar-decompress"></a>
-## Decompress a tarball to a temporary directory
+## Decompress a tarball
 
-[![flate2-badge]][flate2] [![tar-badge]][tar] [![tempdir-badge]][tempdir] [![cat-filesystem-badge]][cat-filesystem] [![cat-compression-badge]][cat-compression]
+[![flate2-badge]][flate2] [![tar-badge]][tar] [![cat-compression-badge]][cat-compression]
 
 Decompress ([`flate2::read::GzDecoder::new`]) and
 extract ([`tar::Archive::unpack`]) all files from a compressed tarball
-named archive.tar.gz located in the current working directory
-inside a temporary directory ([`tempdir::TempDir::new`])
-and delete everything.
+named `archive.tar.gz` located in the current working directory.
 
 ```rust,no_run
 # #[macro_use]
 # extern crate error_chain;
 extern crate flate2;
 extern crate tar;
-extern crate tempdir;
 
 use std::fs::File;
 use flate2::read::GzDecoder;
 use tar::Archive;
-use tempdir::TempDir;
 #
 # error_chain! {
 #     foreign_links {
@@ -136,17 +132,14 @@ use tempdir::TempDir;
 fn run() -> Result<()> {
     let path = "archive.tar.gz";
 
-    // Open our zipped tarball
+    // Open a compressed tarball
     let tar_gz = File::open(path)?;
-    // Uncompressed it
+    // Decompress it
     let tar = GzDecoder::new(tar_gz)?;
     // Load the archive from the tarball
     let mut archive = Archive::new(tar);
-    // Create a directory inside of `std::env::temp_dir()`, named with
-    // the prefix "temp".
-    let tmp_dir = TempDir::new("temp")?;
-    // Unpack the archive inside the temporary directory
-    archive.unpack(tmp_dir.path())?;
+    // Unpack the archive inside curent working directory
+    archive.unpack(".")?;
 
     Ok(())
 }
@@ -281,15 +274,12 @@ fn main() {
 [flate2]: https://docs.rs/flate2/
 [tar-badge]: https://badge-cache.kominick.com/crates/v/tar.svg?label=tar
 [tar]: https://docs.rs/tar/
-[tempdir-badge]: https://badge-cache.kominick.com/crates/v/tempdir.svg?label=tempdir
-[tempdir]: https://docs.rs/tempdir/
 [walkdir-badge]: https://badge-cache.kominick.com/crates/v/walkdir.svg?label=walkdir
 [walkdir]: https://docs.rs/walkdir/
 
 <!-- Reference -->
 
-[`flate2::read::GzDecoder::new`]: https://docs.rs/flate2/0.2.19/flate2/read/struct.GzDecoder.html#method.new
-[`tar::Archive::unpack`]: https://docs.rs/tar/0.4.12/tar/struct.Archive.html#method.new
-[`tempdir::TempDir::new`]: https://docs.rs/tempdir/0.3.5/tempdir/struct.TempDir.html#method.new
+[`flate2::read::GzDecoder::new`]: https://docs.rs/flate2/*/flate2/read/struct.GzDecoder.html#method.new
+[`tar::Archive::unpack`]: https://docs.rs/tar/*/tar/struct.Archive.html#method.unpack
 [`WalkDir::min_depth`]: https://docs.rs/walkdir/*/walkdir/struct.WalkDir.html#method.min_depth
 [`WalkDir::max_depth`]: https://docs.rs/walkdir/*/walkdir/struct.WalkDir.html#method.max_depth

--- a/src/app.md
+++ b/src/app.md
@@ -3,7 +3,7 @@
 | Recipe | Crates | Categories |
 |--------|--------|------------|
 | [Parse command line arguments][ex-clap-basic] | [![clap-badge]][clap] | [![cat-command-line-badge]][cat-command-line] |
-| [Unzip a tarball to a temporary directory][ex-tar-temp] | [![flate2-badge]][flate2] [![tar-badge]][tar] [![tempdir-badge]][tempdir] | [![cat-filesystem-badge]][cat-filesystem] [![cat-compression-badge]][cat-compression] |
+| [Decompress a tarball to a temporary directory][ex-tar-decompress] | [![flate2-badge]][flate2] [![tar-badge]][tar] [![tempdir-badge]][tempdir] | [![cat-filesystem-badge]][cat-filesystem] [![cat-compression-badge]][cat-compression] |
 | [Recursively find duplicate file names][ex-dedup-filenames] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Recursively find all files with given predicate][ex-file-predicate] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Recursively calculate file sizes at given depth][ex-file-sizes] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
@@ -103,14 +103,14 @@ The file passed is: myfile.txt
 Your favorite number must be 256.
 ```
 
-[ex-tar-temp]: #ex-tar-temp
-<a name="ex-tar-temp"></a>
-## Unzip a tarball to a temporary directory
+[ex-tar-decompress]: #ex-tar-decompress
+<a name="ex-tar-decompress"></a>
+## Decompress a tarball to a temporary directory
 
 [![flate2-badge]][flate2] [![tar-badge]][tar] [![tempdir-badge]][tempdir] [![cat-filesystem-badge]][cat-filesystem] [![cat-compression-badge]][cat-compression]
 
-Uncompress ([`flate2::read::GzDecoder::new`]) and
-extract ([`tar::Archive::unpack`]) all files form a zipped tarball
+Decompress ([`flate2::read::GzDecoder::new`]) and
+extract ([`tar::Archive::unpack`]) all files from a compressed tarball
 named archive.tar.gz located in the current working directory
 inside a temporary directory ([`tempdir::TempDir::new`])
 and delete everything.

--- a/src/app.md
+++ b/src/app.md
@@ -4,6 +4,7 @@
 |--------|--------|------------|
 | [Parse command line arguments][ex-clap-basic] | [![clap-badge]][clap] | [![cat-command-line-badge]][cat-command-line] |
 | [Decompress a tarball][ex-tar-decompress] | [![flate2-badge]][flate2] [![tar-badge]][tar] | [![cat-compression-badge]][cat-compression] |
+| [Compress a directory into a tarball][ex-tar-compress] | [![flate2-badge]][flate2] [![tar-badge]][tar] | [![cat-compression-badge]][cat-compression] |
 | [Recursively find duplicate file names][ex-dedup-filenames] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Recursively find all files with given predicate][ex-file-predicate] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Recursively calculate file sizes at given depth][ex-file-sizes] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
@@ -146,6 +147,48 @@ fn run() -> Result<()> {
 #
 # quick_main!(run);
 ```
+
+[ex-tar-compress]: #ex-tar-compress
+<a name="ex-tar-compress"></a>
+## Compress a directory into tarball
+
+[![flate2-badge]][flate2] [![tar-badge]][tar] [![cat-compression-badge]][cat-compression]
+
+Compresses `/var/log` directory into `archive.tar.gz`.
+
+Creates a [`File`] wrapped in [`flate2::write::GzEncoder`]
+and [`tar::Builder`]. </br>Adds contents of `/var/log` directory recursively into the archive
+under `backup/logs`path with [`Builder::append_dir_all`].
+[`flate2::write::GzEncoder`] is responsible for transparently compressing the
+data prior to writing it into `archive.tar.gz`.
+
+```rust,no_run
+# #[macro_use]
+# extern crate error_chain;
+extern crate tar;
+extern crate flate2;
+#
+# error_chain! {
+#     foreign_links {
+#         Io(std::io::Error);
+#     }
+# }
+
+use std::fs::File;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+
+fn run() -> Result<()> {
+    let tar_gz = File::create("archive.tar.gz")?;
+    let enc = GzEncoder::new(tar_gz, Compression::Default);
+    let mut tar = tar::Builder::new(enc);
+    tar.append_dir_all("backup/logs", "/var/log")?;
+    Ok(())
+}
+#
+# quick_main!(run);
+```
+
 [ex-dedup-filenames]: #ex-dedup-filenames
 <a name="ex-dedup-filenames"></a>
 ## Recursively find duplicate file names
@@ -279,7 +322,11 @@ fn main() {
 
 <!-- Reference -->
 
+[`File`]: https://doc.rust-lang.org/std/fs/struct.File.html
 [`flate2::read::GzDecoder::new`]: https://docs.rs/flate2/*/flate2/read/struct.GzDecoder.html#method.new
+[`flate2::write::GzEncoder`]: https://docs.rs/flate2/*/flate2/write/struct.GzEncoder.html
 [`tar::Archive::unpack`]: https://docs.rs/tar/*/tar/struct.Archive.html#method.unpack
+[`tar::Builder`]: https://docs.rs/tar/*/tar/struct.Builder.html
+[`Builder::append_dir_all`]: https://docs.rs/tar/*/tar/struct.Builder.html#method.append_dir_all
 [`WalkDir::min_depth`]: https://docs.rs/walkdir/*/walkdir/struct.WalkDir.html#method.min_depth
 [`WalkDir::max_depth`]: https://docs.rs/walkdir/*/walkdir/struct.WalkDir.html#method.max_depth

--- a/src/intro.md
+++ b/src/intro.md
@@ -75,6 +75,7 @@ community. It needs and welcomes help. For details see
 |--------|--------|------------|
 | [Parse command line arguments][ex-clap-basic] | [![clap-badge]][clap] | [![cat-command-line-badge]][cat-command-line] |
 | [Decompress a tarball][ex-tar-decompress] | [![flate2-badge]][flate2] [![tar-badge]][tar] | [![cat-compression-badge]][cat-compression] |
+| [Compress a directory into a tarball][ex-tar-compress] | [![flate2-badge]][flate2] [![tar-badge]][tar] | [![cat-compression-badge]][cat-compression] |
 | [Recursively find duplicate file names][ex-dedup-filenames] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Recursively find all files with given predicate][ex-file-predicate] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Recursively calculate file sizes at given depth][ex-file-sizes] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
@@ -230,6 +231,7 @@ Keep lines sorted.
 [ex-rest-head]: net.html#ex-rest-head
 [ex-rest-post]: net.html#ex-rest-post
 [ex-std-read-lines]: basics.html#ex-std-read-lines
+[ex-tar-compress]: app.html#ex-tar-compress
 [ex-tar-decompress]: app.html#ex-tar-decompress
 [ex-toml-config]: encoding.html#ex-toml-config
 [ex-url-base]: net.html#ex-url-base

--- a/src/intro.md
+++ b/src/intro.md
@@ -74,7 +74,7 @@ community. It needs and welcomes help. For details see
 | Recipe | Crates | Categories |
 |--------|--------|------------|
 | [Parse command line arguments][ex-clap-basic] | [![clap-badge]][clap] | [![cat-command-line-badge]][cat-command-line] |
-| [Unzip a tarball to a temporary directory][ex-tar-temp] | [![flate2-badge]][flate2] [![tar-badge]][tar] [![tempdir-badge]][tempdir] | [![cat-filesystem-badge]][cat-filesystem] [![cat-compression-badge]][cat-compression] |
+| [Decompress a tarball to a temporary directory][ex-tar-decompress] | [![flate2-badge]][flate2] [![tar-badge]][tar] [![tempdir-badge]][tempdir] | [![cat-filesystem-badge]][cat-filesystem] [![cat-compression-badge]][cat-compression] |
 | [Recursively find duplicate file names][ex-dedup-filenames] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Recursively find all files with given predicate][ex-file-predicate] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Recursively calculate file sizes at given depth][ex-file-sizes] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
@@ -230,7 +230,7 @@ Keep lines sorted.
 [ex-rest-head]: net.html#ex-rest-head
 [ex-rest-post]: net.html#ex-rest-post
 [ex-std-read-lines]: basics.html#ex-std-read-lines
-[ex-tar-temp]: app.html#ex-tar-temp
+[ex-tar-decompress]: app.html#ex-tar-decompress
 [ex-toml-config]: encoding.html#ex-toml-config
 [ex-url-base]: net.html#ex-url-base
 [ex-url-basic]: net.html#ex-url-basic

--- a/src/intro.md
+++ b/src/intro.md
@@ -74,7 +74,7 @@ community. It needs and welcomes help. For details see
 | Recipe | Crates | Categories |
 |--------|--------|------------|
 | [Parse command line arguments][ex-clap-basic] | [![clap-badge]][clap] | [![cat-command-line-badge]][cat-command-line] |
-| [Decompress a tarball to a temporary directory][ex-tar-decompress] | [![flate2-badge]][flate2] [![tar-badge]][tar] [![tempdir-badge]][tempdir] | [![cat-filesystem-badge]][cat-filesystem] [![cat-compression-badge]][cat-compression] |
+| [Decompress a tarball][ex-tar-decompress] | [![flate2-badge]][flate2] [![tar-badge]][tar] | [![cat-compression-badge]][cat-compression] |
 | [Recursively find duplicate file names][ex-dedup-filenames] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Recursively find all files with given predicate][ex-file-predicate] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Recursively calculate file sizes at given depth][ex-file-sizes] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |


### PR DESCRIPTION
- Added "Compress a directory into tarball" example
- Reworded the example to use Decompress consistently
    - removed tempdir
    - fixed api links

fixes: https://github.com/brson/rust-cookbook/issues/188
fixes: https://github.com/brson/rust-cookbook/issues/186

cc: https://github.com/brson/rust-cookbook/issues/185