### PR TITLE
MathJax CDN has closed down.

### DIFF
--- a/src/incomplete/rand.md
+++ b/src/incomplete/rand.md
@@ -15,7 +15,7 @@ MathJax.Hub.Queue(function() {
     }
 });
 </script>
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
 # rand
 ## Random number generators and other randomness functionality

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -22,7 +22,7 @@
         <link rel="stylesheet" href="tomorrow-night.css">
 
         <!-- MathJax -->
-        <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
         <!-- Fetch JQuery from CDN but have a local fallback -->
         <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>


### PR DESCRIPTION
I noticed an js console warning when navigating the cookbook:

```WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.```

So heres a PR with the location updated as per their [guidance](https://www.mathjax.org/cdn-shutting-down/).