### PR TITLE
Basics: improve random number examples

### DIFF
--- a/src/basics.md
+++ b/src/basics.md
@@ -4,7 +4,7 @@
 |--------|--------|------------|
 | [Read lines of strings from a file][ex-std-read-lines] | [![std-badge]][std] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Read and write integers in little-endian byte order][ex-byteorder-le] | [![byteorder-badge]][byteorder] | [![cat-encoding-badge]][cat-encoding] |
-| [Generate random floating point numbers][ex-rand-float] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
+| [Generate random numbers for simple types][ex-rand-simple] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Generate random numbers within a range][ex-rand-range] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Generate random numbers with normal distribution][ex-rand-dist] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Generate random values of a custom type][ex-rand-custom] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
@@ -111,9 +111,11 @@ fn decode(mut bytes: &[u8]) -> Result<Payload> {
 # quick_main!(run);
 ```
 
-[ex-rand-float]: #ex-rand-float
-<a name="ex-rand-float"></a>
-## Generate random floating point numbers
+[ex-rand-simple]: #ex-rand-simple
+<a name="ex-rand-simple"></a>
+## Generate random numbers for simple types
+
+The `rand` crate provides a convenient source of psuedo-random numbers.
 
 [![rand-badge]][rand] [![cat-science-badge]][cat-science]
 
@@ -122,9 +124,28 @@ extern crate rand;
 use rand::Rng;
 
 fn main() {
+    // Each thread has an automatically-initialised random number generator:
     let mut rng = rand::thread_rng();
-    println!("Random f64: {}", rng.gen::<f64>());
+    
+    // Integers are uniformly distributed over the type's whole range:
+    let n1: u32 = rng.gen();
+    let n2: u16 = rng.gen();
+    let n3: u8 = rng.gen();
+    println!("Random u32, u16, u8: {}, {}, {}", n1, n2, n3);
+    println!("Random i32: {}", rng.gen::<i32>());
+    
+    // Floating point numbers are uniformly distributed in the half-open range [0, 1)
+    println!("Random float: {}", rng.gen::<f64>());
+    println!("Random floats: {:?}", (0..5).map(|_| rng.gen()).collect::<Vec<f32>>());
 }
+```
+
+Example output:
+```
+Random u32, u16, u8: 1224630198, 31187, 43
+Random i32: -515338046
+Random float: 0.7258180295601702
+Random floats: [0.6633928, 0.4400041, 0.49633145, 0.02997303, 0.41612816]
 ```
 
 [ex-rand-range]: #ex-rand-range
@@ -142,9 +163,34 @@ use rand::Rng;
 
 fn main() {
     let mut rng = rand::thread_rng();
-    println!("{}", rng.gen_range(0, 10));
+    println!("Integer: {}", rng.gen_range(0, 10));
+    println!("Float: {}", rng.gen_range(0.0, 10.0));
 }
 ```
+
+Alternatively, one can use the [`Range`](https://doc.rust-lang.org/rand/rand/distributions/range/struct.Range.html) distribution.
+This has the same effect, but may be faster when repeatedly generating numbers
+in the same range.
+
+```rust
+extern crate rand;
+
+use rand::distributions::{Range, IndependentSample};
+
+fn main() {
+    let mut rng = rand::thread_rng();
+    let die = Range::new(1, 7);
+    
+    loop {
+        let throw = die.ind_sample(&mut rng);
+        println!("Roll the die: {}", throw);
+        if throw == 6 {
+            break;
+        }
+    }
+}
+```
+
 
 [ex-rand-dist]: #ex-rand-dist
 <a name="ex-rand-dist"></a>

--- a/src/basics.md
+++ b/src/basics.md
@@ -4,9 +4,9 @@
 |--------|--------|------------|
 | [Read lines of strings from a file][ex-std-read-lines] | [![std-badge]][std] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Read and write integers in little-endian byte order][ex-byteorder-le] | [![byteorder-badge]][byteorder] | [![cat-encoding-badge]][cat-encoding] |
-| [Generate random numbers for simple types][ex-rand-simple] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
+| [Generate random numbers][ex-rand] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Generate random numbers within a range][ex-rand-range] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
-| [Generate random numbers with normal distribution][ex-rand-dist] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
+| [Generate random distributions][ex-rand-dist] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Generate random values of a custom type][ex-rand-custom] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Run an external command and process stdout][ex-parse-subprocess-output] | [![regex-badge]][regex] | [![cat-os-badge]][cat-os] [![cat-text-processing-badge]][cat-text-processing] |
 | [Declare lazily evaluated constant][ex-lazy-constant] | [![lazy_static-badge]][lazy_static] | [![cat-caching-badge]][cat-caching] [![cat-rust-patterns-badge]][cat-rust-patterns] |
@@ -111,11 +111,11 @@ fn decode(mut bytes: &[u8]) -> Result<Payload> {
 # quick_main!(run);
 ```
 
-[ex-rand-simple]: #ex-rand-simple
-<a name="ex-rand-simple"></a>
-## Generate random numbers for simple types
+[ex-rand]: #ex-rand
+<a name="ex-rand"></a>
+## Generate random numbers
 
-The `rand` crate provides a convenient source of psuedo-random numbers.
+The [`rand`] crate provides a convenient source of psuedo-random numbers.
 
 [![rand-badge]][rand] [![cat-science-badge]][cat-science]
 
@@ -128,24 +128,14 @@ fn main() {
     let mut rng = rand::thread_rng();
     
     // Integers are uniformly distributed over the type's whole range:
-    let n1: u32 = rng.gen();
+    let n1: u8 = rng.gen();
     let n2: u16 = rng.gen();
-    let n3: u8 = rng.gen();
-    println!("Random u32, u16, u8: {}, {}, {}", n1, n2, n3);
+    println!("Random u8: {}; random u16: {}", n1, n2);
     println!("Random i32: {}", rng.gen::<i32>());
     
     // Floating point numbers are uniformly distributed in the half-open range [0, 1)
     println!("Random float: {}", rng.gen::<f64>());
-    println!("Random floats: {:?}", (0..5).map(|_| rng.gen()).collect::<Vec<f32>>());
 }
-```
-
-Example output:
-```
-Random u32, u16, u8: 1224630198, 31187, 43
-Random i32: -515338046
-Random float: 0.7258180295601702
-Random floats: [0.6633928, 0.4400041, 0.49633145, 0.02997303, 0.41612816]
 ```
 
 [ex-rand-range]: #ex-rand-range
@@ -168,7 +158,7 @@ fn main() {
 }
 ```
 
-Alternatively, one can use the [`Range`](https://doc.rust-lang.org/rand/rand/distributions/range/struct.Range.html) distribution.
+Alternatively, one can use the [`Range`] distribution (otherwise known as uniform).
 This has the same effect, but may be faster when repeatedly generating numbers
 in the same range.
 
@@ -194,12 +184,17 @@ fn main() {
 
 [ex-rand-dist]: #ex-rand-dist
 <a name="ex-rand-dist"></a>
-## Generate random numbers with normal distribution
+## Random number distributions
 
 [![rand-badge]][rand] [![cat-science-badge]][cat-science]
 
-Creates a [`Normal`] distribution with mean `3` and standard deviation `5`
-and generates a random value with [`IndependentSample::ind_sample`].
+You've already seen how to create numbers with uniform distribution [above][ex-rand-range]
+(using [`Range`]). Other distributions are used in the same way: create a distribution, then
+sample from that distribution (using [`IndependentSample::ind_sample`]) with the help of
+a random-number generator (`rng`).
+
+The [distributions available are documented here][rand-distributions]. An example using the
+[`Normal`] distribution is shown below.
 
 ```rust
 extern crate rand;
@@ -207,10 +202,12 @@ extern crate rand;
 use rand::distributions::{Normal, IndependentSample};
 
 fn main() {
-    let normal = Normal::new(3.0, 5.0);
     let mut rng = rand::thread_rng();
+    
+    // mean 2, standard deviation 3:
+    let normal = Normal::new(2.0, 3.0);
     let v = normal.ind_sample(&mut rng);
-    println!("{} is from a N(3, 25) distribution", v)
+    println!("{} is from a N(2, 9) distribution", v)
 }
 ```
 
@@ -566,8 +563,11 @@ fn main() {
 [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
 [`Normal`]: https://doc.rust-lang.org/rand/rand/distributions/normal/struct.Normal.html
 [`IndependentSample::ind_sample`]: https://doc.rust-lang.org/rand/rand/distributions/trait.IndependentSample.html#tymethod.ind_sample
+[`rand`]: https://doc.rust-lang.org/rand
 [`Rng::gen_range`]: https://doc.rust-lang.org/rand/rand/trait.Rng.html#method.gen_range
 [`rand::Rand`]: https://doc.rust-lang.org/rand/rand/trait.Rand.html
+[`Range`]: https://doc.rust-lang.org/rand/rand/distributions/range/struct.Range.html
+[rand-distributions]: https://doc.rust-lang.org/rand/rand/distributions/index.html
 [`Regex`]: https://doc.rust-lang.org/regex/regex/struct.Regex.html
 [`Output`]: https://doc.rust-lang.org/std/process/struct.Output.html
 [`Command`]: https://doc.rust-lang.org/std/process/struct.Command.html

--- a/src/intro.md
+++ b/src/intro.md
@@ -22,9 +22,9 @@ community. It needs and welcomes help. For details see
 |--------|--------|------------|
 | [Read lines of strings from a file][ex-std-read-lines] | [![std-badge]][std] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Read and write integers in little-endian byte order][ex-byteorder-le] | [![byteorder-badge]][byteorder] | [![cat-encoding-badge]][cat-encoding] |
-| [Generate random floating point numbers][ex-rand-float] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
+| [Generate random numbers][ex-rand] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Generate random numbers within a range][ex-rand-range] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
-| [Generate random numbers with normal distribution][ex-rand-dist] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
+| [Generate random number distributions][ex-rand-dist] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Generate random values of a custom type][ex-rand-custom] | [![rand-badge]][rand] | [![cat-science-badge]][cat-science] |
 | [Run an external command and process stdout][ex-parse-subprocess-output] | [![regex-badge]][regex] | [![cat-os-badge]][cat-os] [![cat-text-processing-badge]][cat-text-processing] |
 | [Declare lazily evaluated constant][ex-lazy-constant] | [![lazy_static-badge]][lazy_static] | [![cat-caching-badge]][cat-caching] [![cat-rust-patterns-badge]][cat-rust-patterns] |
@@ -247,7 +247,7 @@ Keep lines sorted.
 [ex-percent-encode]: encoding.html#ex-percent-encode
 [ex-rand-custom]: basics.html#ex-rand-custom
 [ex-rand-dist]: basics.html#ex-rand-dist
-[ex-rand-float]: basics.html#ex-rand-float
+[ex-rand]: basics.html#ex-rand
 [ex-rand-range]: basics.html#ex-rand-range
 [ex-random-port-tcp]: net.html#ex-random-port-tcp
 [ex-rayon-iter-mut]: concurrency.html#ex-rayon-iter-mut


### PR DESCRIPTION
I noticed the random examples were quite short and didn't document range for floating point cases. Improved.

Caveat: this doesn't explain why the `.ind_sample` method is used. I don't understand myself why the `Sample` trait (taking mutable reference to the range) exists, and if it does have a use-case it should probably have been named `MutSample`. But I digress.